### PR TITLE
Add support for migrations for tables and indices

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,8 @@ use Mix.Config
 #
 
 config :rethinkdb_ecto, RethinkDB.EctoTest.Repo,
-  adapter: RethinkDB.Ecto
+  adapter: RethinkDB.Ecto,
+  database: 'test'
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/test/migration_test.exs
+++ b/test/migration_test.exs
@@ -1,0 +1,67 @@
+defmodule RethinkDB.MigrationTest do
+  use ExUnit.Case
+  alias RethinkDB.EctoTest.Repo
+  doctest RethinkDB.Ecto
+
+  @table_name "test_table"
+
+  setup_all do
+    Repo.start_link
+    RethinkDB.Query.table_drop(:schema_migrations) |> Repo.run
+    RethinkDB.Query.table_drop(:test_table) |> Repo.run
+    RethinkDB.Query.table_drop(:other_test_test_table) |> Repo.run
+    RethinkDB.Query.table_create(:schema_migrations) |> Repo.run
+    :ok
+  end
+
+  defmodule CreateTableMigrationTest do
+    use Ecto.Migration
+    def change do
+      create table(:test_table)
+    end
+  end
+
+  defmodule CreateTablePrefixMigrationTest do
+    use Ecto.Migration
+    def change do
+      create table(:test_table, prefix: :other_test)
+    end
+  end
+
+  defmodule CreateTestIndex do
+    use Ecto.Migration
+    def change do
+      create index(:test_table, [:name])
+    end
+  end
+
+  test "create and drop table" do
+    Ecto.Migrator.up(Repo, 1, CreateTableMigrationTest, [log: false])
+    %RethinkDB.Record{data: data} = RethinkDB.Query.table_list |> Repo.run
+    assert Enum.find(data, &(&1 == @table_name)), "#{@table_name} not found in #{inspect data}"
+    Ecto.Migrator.down(Repo, 1, CreateTableMigrationTest, [log: false])
+    %RethinkDB.Record{data: data} = RethinkDB.Query.table_list |> Repo.run
+    assert Enum.find(data, &(&1 == @table_name)) == nil
+  end
+
+  test "create and drop table with db prefix" do
+    RethinkDB.Query.db_create("other_test") |> Repo.run
+    Ecto.Migrator.up(Repo, 1, CreateTablePrefixMigrationTest, [log: false])
+    %RethinkDB.Record{data: data} = RethinkDB.Query.table_list |> Repo.run()
+    assert Enum.find(data, &(&1 == @table_name))
+    Ecto.Migrator.down(Repo, 1, CreateTablePrefixMigrationTest, [log: false])
+    %RethinkDB.Record{data: data} = RethinkDB.Query.table_list |> Repo.run()
+    assert Enum.find(data, &(&1 == @table_name)) == nil
+    RethinkDB.Query.db_drop("other_test") |> Repo.run
+  end
+
+  test "create and drop index" do
+    RethinkDB.Query.table_create("test_table") |> Repo.run
+    Ecto.Migrator.up(Repo, 1, CreateTestIndex, [log: false])
+    %RethinkDB.Record{data: data} = RethinkDB.Query.table("test_table") |> RethinkDB.Query.index_list |> Repo.run
+    assert Enum.find(data, &(&1 == "name"))
+    Ecto.Migrator.down(Repo, 1, CreateTestIndex, [log: false])
+    %RethinkDB.Record{data: data} = RethinkDB.Query.table("test_table") |> RethinkDB.Query.index_list |> Repo.run
+    assert length(data) == 0
+  end
+end


### PR DESCRIPTION
Hi! Here's another pull request from me. This one adds migrations (creation/dropping of tables/indices) support. The code is mostly taken from another repo's experimental branch (with no plans of support), as discussed here: https://github.com/hamiltop/rethinkdb_ecto/issues/13#issuecomment-210017317. 

This time there are even some tests.