### PR TITLE
Goyox86/improve options handling

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,8 @@ use Mix.Config
 
 config :rethinkdb_ecto, RethinkDB.EctoTest.Repo,
   adapter: RethinkDB.Ecto,
-  database: 'test'
+  database: "test",
+  host: "localhost"
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,6 @@ defmodule RethinkDB.Ecto.Mixfile do
       source_url: "https://github.com/almightycouch/rethinkdb_ecto"]
   end
 
-
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:ecto, "~> 1.1"},

--- a/test/rethinkdb_ecto_test.exs
+++ b/test/rethinkdb_ecto_test.exs
@@ -35,6 +35,9 @@ defmodule RethinkDB.EctoTest do
     # Start the Repo as worker of the supervisor tree
     Supervisor.start_link([worker(Repo, [])], strategy: :one_for_one)
 
+    # Create the table
+    RethinkDB.Query.table_create(:users) |> Repo.run
+
     # Clear table
     table("users")
     |> delete


### PR DESCRIPTION
Hi People!

I'm starting a project and we are planning to use RethinkDB in a Phoenix app. I don't know if this is even the right way to do it but here we go. 

I setup a small phoenix app and configured `RethinkDB.Ecto` and generated a small User model. Then I just ran `mix ecto.create` and `mix ecto.migrate` and according the output everything was fine! . I was so happy because I was good to go then I proceeded to fire up a **iex** session to create a User record which I did. Only to realize that even though `mix ecto.create` did create the DB I had configured `mix ecto.migrate` did not used that DB to create the `users` table on that DB instead it used the _test_ DB which I coincidentally happen to have setup.

After a bit of Googling I came to the idea of setting the `db` option which is the one that [RethinkDB Elixir driver](https://github.com/hamiltop/rethinkdb-elixir) expects. And tried again and I've got this:

``` sh
 mix ecto.create                                                                                                            [20:49:21]
** (RuntimeError) Expected type STRING but found NULL.
    lib/rethinkdb_ecto.ex:119: RethinkDB.Ecto.storage_up/1
    lib/mix/tasks/ecto.create.ex:34: anonymous fn/2 in Mix.Tasks.Ecto.Create.run/1
    (elixir) lib/enum.ex:651: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:651: Enum.each/2
    (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
    (elixir) lib/code.ex:363: Code.require_file/2
```

I keep trying combinations of options until I found a way to make `mix ecto.create` and `ecto.migrate` to yield the results I was expecting. 

1) Set the `database` option and run `mix ecto.create`. 
2) Setting the option `db` and then run `ecto.migrate`. 

Which for someone coming from the Rails world does not make much sense so I treated this as a bug 😉 

What this patch does is to hook into the options parsing and put into `db` and `host` (which are the options the driver expects) the values of the more conventional Ecto options `database` and `hostname` if they are provided giving precedence to `db` and `host` and then normalizing the usage across this library the usage of `db` in order to avoid inconsistencies. I've also added a line to make sure the `users` table is there when running the tests because I spent some time reading them while trying to run them. 

After this you should be able to just drop in the dependency in a project and then run `mix ecto.create` and `mix ecto.migrate` with any combination of db,host,database and hostname options.

Tests are green of course! 
And thanks for the Adapter it will save me a lot of time because I really want to use RethinkDB in our project!

I'm not a en Elixir developer so I don't know if the code is idiomatic but you get the idea 😉 
