### PR TITLE
is_nil should check for equality with nil not the other way around

### DIFF
--- a/lib/rethinkdb_ecto/normalized_query.ex
+++ b/lib/rethinkdb_ecto/normalized_query.ex
@@ -361,7 +361,7 @@ defmodule RethinkDB.Ecto.NormalizedQuery do
       :and -> apply(ReQL, :and_r, args)
       :or  -> apply(ReQL, :or_r, args)
       :not -> apply(ReQL, :not_r, args)
-      :is_nil -> apply(ReQL, :ne, args ++ [nil])
+      :is_nil -> apply(ReQL, :eq, args ++ [nil])
       :field  -> apply(ReQL, :bracket, args)
       :like   -> like(args)
       :ilike  -> like(args, true)


### PR DESCRIPTION
I think the logic is inverted here... 

I was doing something in one of my projects and found out that negating the `is_nil` expression yields results I wanted - `where: not is_nil(p.end)`. This led me to the line I changed in this PR, I am not sure this is the actual fix because I had a hard time understanding the internals, hence the missing tests...